### PR TITLE
Support use `pipeline.conf` and `lookup.json` from any path

### DIFF
--- a/charts/feathr-online/templates/configmap.yaml
+++ b/charts/feathr-online/templates/configmap.yaml
@@ -4,7 +4,16 @@ metadata:
   name: feathr-online-config
   namespace: {{ .Release.Name }}
 data:
-  pipeline.conf: {{ .Files.Get ( required ".Values.pipelineConf is required." .Values.pipelineConf) | indent 4 }}
-  {{ if .Values.lookup }}
-  lookup.json: {{ .Files.Get .Values.lookup | toPrettyJson }}
+  # pipeline.conf and lookup.json needs to be encoded with Base64
+  pipeline.conf: |
+    {{ range ( required ".Values.pipelineConf is required." .Values.pipelineConf | b64dec) | toStrings }}
+    {{ . | nindent 8 }}
   {{ end }}
+
+  {{ if .Values.lookup }}
+  lookup.json: | 
+    {{ range ( .Values.lookup | b64dec) | toStrings }}
+    {{ . | nindent 8 }}
+    {{ end }}
+  {{ end }}
+  


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/feathr-ai/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe what changes to make and why you are making these changes.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Added configmap from any path for environment variables of Feathr
Resolves https://github.com/feathr-ai/helm-charts/issues/11

## How was this PR tested?
<!--
Describe what testings you have done. If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->
Run the following command to pass `pipeline.conf` and `lookup.json` to configmap.
```sh
helm install chang ./feathr-online \ 
    --set pipelineConf=$(cat /Users/changyonglik/Desktop/pipeline.conf | base64) \
    --set lookup=$(cat /Users/changyonglik/Desktop/lookup.json | base64) --dry-run
```

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide UI screenshot, the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.